### PR TITLE
Adding Docker support

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,5 +1,7 @@
 # Build notes
 
+## Node (normal build)
+
 1. `cp .env.example .env` -- adjust this config to your environment.
 2. `npm install`
 3. `npx prisma db push`
@@ -7,3 +9,10 @@
 5. `node server.js`
 
 For dev build, replace steps 4-5 with `npm run dev -- --host`.
+
+## Docker Compose
+
+1. `cp .env.example .env` -- adjust this config to your environment.
+2. `docker compose up --build -d`
+
+Whenever you change environment variables in `.env`, rebuild the container to have the changes take effect.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM "node:alpine"
+
+WORKDIR /code
+
+COPY package.json .
+
+RUN npm install
+
+COPY . .
+
+RUN npx prisma db push && npm run build
+
+EXPOSE 3123
+
+CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  app:
+    build: .
+    container_name: chessdriller
+    ports:
+      - "3123:3123"
+    volumes:
+      - ./prisma:/code/prisma
+    restart: unless-stopped
+    environment:
+      - NODE_ENV=production


### PR DESCRIPTION
This PR adds support for easily running `chessdriller` in a Docker container, either with just the Dockerfile or using `docker compose`. I also added a short section in the `BUILD.md` on using those.

Please let me know if there is anything else you need to merge this :).